### PR TITLE
feat: 테이블 명 변경 및 공통 컬럼 정상적으로 적용되도록 수정 #5

### DIFF
--- a/src/main/java/com/autoever/carstore/CarstoreApplication.java
+++ b/src/main/java/com/autoever/carstore/CarstoreApplication.java
@@ -2,8 +2,10 @@ package com.autoever.carstore;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class CarstoreApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/autoever/carstore/agency/entity/AgencyEntity.java
+++ b/src/main/java/com/autoever/carstore/agency/entity/AgencyEntity.java
@@ -14,6 +14,7 @@ import java.math.BigDecimal;
 @AllArgsConstructor
 @Builder
 @Entity
+@Table(name="agency")
 public class AgencyEntity extends BaseTimeEntity {
 
     @Id

--- a/src/main/java/com/autoever/carstore/car/entity/CarEntity.java
+++ b/src/main/java/com/autoever/carstore/car/entity/CarEntity.java
@@ -12,6 +12,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Builder
 @Entity
+@Table(name="car")
 public class CarEntity extends BaseTimeEntity {
 
     @Id

--- a/src/main/java/com/autoever/carstore/car/entity/CarImageEntity.java
+++ b/src/main/java/com/autoever/carstore/car/entity/CarImageEntity.java
@@ -12,6 +12,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @Builder
 @Entity
+@Table(name="car_image")
 public class CarImageEntity extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/autoever/carstore/car/entity/CarModelEntity.java
+++ b/src/main/java/com/autoever/carstore/car/entity/CarModelEntity.java
@@ -12,6 +12,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Builder
 @Entity
+@Table(name="car_model")
 public class CarModelEntity extends BaseTimeEntity {
 
     @Id

--- a/src/main/java/com/autoever/carstore/car/entity/CarPurchaseEntity.java
+++ b/src/main/java/com/autoever/carstore/car/entity/CarPurchaseEntity.java
@@ -15,6 +15,7 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 @Builder
 @Entity
+@Table(name="car_purchase")
 public class CarPurchaseEntity extends BaseTimeEntity {
 
     @Id

--- a/src/main/java/com/autoever/carstore/car/entity/CarPurchaseImageEntity.java
+++ b/src/main/java/com/autoever/carstore/car/entity/CarPurchaseImageEntity.java
@@ -12,6 +12,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @Builder
 @Entity
+@Table(name="car_purchase_image")
 public class CarPurchaseImageEntity extends BaseTimeEntity {
 
     @Id

--- a/src/main/java/com/autoever/carstore/car/entity/CarSalesEntity.java
+++ b/src/main/java/com/autoever/carstore/car/entity/CarSalesEntity.java
@@ -16,6 +16,7 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 @Builder
 @Entity
+@Table(name="car_sales")
 public class CarSalesEntity extends BaseTimeEntity {
 
     @Id

--- a/src/main/java/com/autoever/carstore/car/entity/CarSalesLikeEntity.java
+++ b/src/main/java/com/autoever/carstore/car/entity/CarSalesLikeEntity.java
@@ -13,6 +13,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Builder
 @Entity
+@Table(name="car_sales_like")
 public class CarSalesLikeEntity extends BaseTimeEntity {
 
     @Id

--- a/src/main/java/com/autoever/carstore/car/entity/CarSalesViewEntity.java
+++ b/src/main/java/com/autoever/carstore/car/entity/CarSalesViewEntity.java
@@ -13,6 +13,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @Builder
 @Entity
+@Table(name="car_sales_view")
 public class CarSalesViewEntity extends BaseTimeEntity {
 
     @Id

--- a/src/main/java/com/autoever/carstore/car/entity/FixedImageEntity.java
+++ b/src/main/java/com/autoever/carstore/car/entity/FixedImageEntity.java
@@ -12,6 +12,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @Builder
 @Entity
+@Table(name="fixed_image")
 public class FixedImageEntity extends BaseTimeEntity {
 
     @Id

--- a/src/main/java/com/autoever/carstore/feed/entity/FeedEntity.java
+++ b/src/main/java/com/autoever/carstore/feed/entity/FeedEntity.java
@@ -14,6 +14,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Getter
 @Entity
+@Table(name="feed")
 public class FeedEntity extends BaseTimeEntity {
 
     @Id

--- a/src/main/java/com/autoever/carstore/hashtag/entity/CarSalesHashtagEntity.java
+++ b/src/main/java/com/autoever/carstore/hashtag/entity/CarSalesHashtagEntity.java
@@ -13,7 +13,8 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Builder
 @Entity
-public class CarSalesHashtag extends BaseTimeEntity {
+@Table(name="car_sales_hashtag")
+public class CarSalesHashtagEntity extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/autoever/carstore/hashtag/entity/FeedHashtagEntity.java
+++ b/src/main/java/com/autoever/carstore/hashtag/entity/FeedHashtagEntity.java
@@ -13,6 +13,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @Builder
 @Entity
+@Table(name="feed_hashtag")
 public class FeedHashtagEntity extends BaseTimeEntity {
 
     @Id

--- a/src/main/java/com/autoever/carstore/hashtag/entity/HashtagEntity.java
+++ b/src/main/java/com/autoever/carstore/hashtag/entity/HashtagEntity.java
@@ -12,6 +12,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @Builder
 @Entity
+@Table(name="hashtag")
 public class HashtagEntity extends BaseTimeEntity {
 
     @Id

--- a/src/main/java/com/autoever/carstore/notification/entity/NotificationEntity.java
+++ b/src/main/java/com/autoever/carstore/notification/entity/NotificationEntity.java
@@ -13,6 +13,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Builder
 @Entity
+@Table(name="notification")
 public class NotificationEntity extends BaseTimeEntity {
 
     @Id

--- a/src/main/java/com/autoever/carstore/recommend/entity/RecommendEntity.java
+++ b/src/main/java/com/autoever/carstore/recommend/entity/RecommendEntity.java
@@ -13,6 +13,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @Builder
 @Entity
+@Table(name="recommend")
 public class RecommendEntity extends BaseTimeEntity {
 
     @Id

--- a/src/main/java/com/autoever/carstore/reservation/entity/ReservationEntity.java
+++ b/src/main/java/com/autoever/carstore/reservation/entity/ReservationEntity.java
@@ -16,6 +16,7 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 @Builder
 @Entity
+@Table(name="reservation")
 public class ReservationEntity extends BaseTimeEntity {
 
     @Id

--- a/src/main/java/com/autoever/carstore/survey/entity/SurveyCarModelEntity.java
+++ b/src/main/java/com/autoever/carstore/survey/entity/SurveyCarModelEntity.java
@@ -13,6 +13,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Builder
 @Entity
+@Table(name="survey_car_model")
 public class SurveyCarModelEntity extends BaseTimeEntity {
 
     @Id

--- a/src/main/java/com/autoever/carstore/survey/entity/SurveyColorEntity.java
+++ b/src/main/java/com/autoever/carstore/survey/entity/SurveyColorEntity.java
@@ -12,6 +12,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Builder
 @Entity
+@Table(name="survey_color")
 public class SurveyColorEntity extends BaseTimeEntity {
 
     @Id

--- a/src/main/java/com/autoever/carstore/survey/entity/SurveyEntity.java
+++ b/src/main/java/com/autoever/carstore/survey/entity/SurveyEntity.java
@@ -13,6 +13,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Builder
 @Entity
+@Table(name="survey")
 public class SurveyEntity extends BaseTimeEntity {
 
     @Id

--- a/src/main/java/com/autoever/carstore/user/entity/UserEntity.java
+++ b/src/main/java/com/autoever/carstore/user/entity/UserEntity.java
@@ -12,6 +12,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Getter
 @Entity
+@Table(name="user")
 public class UserEntity extends BaseTimeEntity {
 
     @Id


### PR DESCRIPTION
테이블 명 변경 및 공통 컬럼 정상적으로 적용되도록 수정 

1. 기존에 뒤에 _entity 붙어있던 부분 없도록 수정
2. 크롤링 데이터 넣으면서 확인해보니 공통 컬럼 값들이 정상적으로 들어가지 않아 들어가도록 수정

#5